### PR TITLE
Jackson Mapper should accept java-8 date/time values

### DIFF
--- a/opa-async-java-client/build.gradle
+++ b/opa-async-java-client/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     api project(":rego-java")
 
     api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jacksonVersion}"
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/opa-async-java-client/src/main/java/eu/xenit/contentcloud/opa/client/OpaClient.java
+++ b/opa-async-java-client/src/main/java/eu/xenit/contentcloud/opa/client/OpaClient.java
@@ -1,10 +1,12 @@
 package eu.xenit.contentcloud.opa.client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import eu.xenit.contentcloud.opa.client.api.CompileApi;
 import eu.xenit.contentcloud.opa.client.api.DataApi;
-import eu.xenit.contentcloud.opa.client.api.QueryApi;
 import eu.xenit.contentcloud.opa.client.api.PolicyApi;
+import eu.xenit.contentcloud.opa.client.api.QueryApi;
 import eu.xenit.contentcloud.opa.client.impl.CompileComponent;
 import eu.xenit.contentcloud.opa.client.impl.DataComponent;
 import eu.xenit.contentcloud.opa.client.impl.PolicyComponent;
@@ -48,7 +50,7 @@ public class OpaClient implements PolicyApi, QueryApi, DataApi, CompileApi {
 
     @Override
     public CompletableFuture<ListPoliciesResponse> listPolicies() {
-         return this.policyComponent.listPolicies();
+        return this.policyComponent.listPolicies();
     }
 
     @Override
@@ -97,8 +99,14 @@ public class OpaClient implements PolicyApi, QueryApi, DataApi, CompileApi {
          * The default rest-client
          */
         private OpaHttpClient restClient = new DefaultOpaHttpClient(
-                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).followRedirects(Redirect.NORMAL).build(),
-                new ObjectMapper());
+                HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(5))
+                        .followRedirects(Redirect.NORMAL)
+                        .build(),
+                JsonMapper.builder()
+                        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                        .build()
+                        .registerModule(new JavaTimeModule()));
 
         private Consumer<LogSpecification> httpLogSpec = LogSpecification::verbose;
 

--- a/opa-async-java-client/src/main/java/eu/xenit/contentcloud/opa/client/rest/client/jdk/DefaultOpaHttpClient.java
+++ b/opa-async-java-client/src/main/java/eu/xenit/contentcloud/opa/client/rest/client/jdk/DefaultOpaHttpClient.java
@@ -3,9 +3,9 @@ package eu.xenit.contentcloud.opa.client.rest.client.jdk;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.xenit.contentcloud.opa.client.rest.OpaHttpClient;
 import eu.xenit.contentcloud.opa.client.rest.RestClientConfiguration;
+import eu.xenit.contentcloud.opa.client.rest.client.jdk.converter.ConverterProcessor;
 import eu.xenit.contentcloud.opa.client.rest.client.jdk.converter.HttpBodyConverter.DeserializationContext;
 import eu.xenit.contentcloud.opa.client.rest.client.jdk.converter.HttpBodyConverter.SerializationContext;
-import eu.xenit.contentcloud.opa.client.rest.client.jdk.converter.ConverterProcessor;
 import eu.xenit.contentcloud.opa.client.rest.client.jdk.converter.JacksonBodyConverter;
 import eu.xenit.contentcloud.opa.client.rest.client.jdk.converter.StringConverter;
 import eu.xenit.contentcloud.opa.client.rest.http.HttpMethod;
@@ -27,7 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 public class DefaultOpaHttpClient implements OpaHttpClient {
 
     private final HttpClient httpClient;
-    private final ObjectMapper objectMapper;
     private final ConverterProcessor converterProcessor;
 
     private URI baseUrl;
@@ -42,11 +41,10 @@ public class DefaultOpaHttpClient implements OpaHttpClient {
 
     public DefaultOpaHttpClient(HttpClient httpClient, ObjectMapper objectMapper) {
         this.httpClient = httpClient;
-        this.objectMapper = objectMapper;
 
         this.converterProcessor = new ConverterProcessor(List.of(
                 new StringConverter(),
-                new JacksonBodyConverter()
+                new JacksonBodyConverter(objectMapper)
         ));
     }
 
@@ -88,7 +86,6 @@ public class DefaultOpaHttpClient implements OpaHttpClient {
 
         callback.accept(config);
     }
-
 
 
     private <TRequest, TResponse> CompletableFuture<TResponse> execute(
@@ -134,8 +131,6 @@ public class DefaultOpaHttpClient implements OpaHttpClient {
                     return this.converterProcessor.read(context, responseType);
                 });
     }
-
-
 
 
     private void handleStatusCode(HttpResponse<byte[]> response, Throwable exception) {


### PR DESCRIPTION
The provided object mapper has the JavaTimeModule registered and is used for the conversion.