### PR TITLE
ACC-1924: use fixed opa version in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,9 @@ jobs:
           ORG_GRADLE_PROJECT_sonatype_username: ${{ secrets.SONATYPE_S01_USERNAME }}
           ORG_GRADLE_PROJECT_sonatype_password: ${{ secrets.SONATYPE_S01_PASSWORD }}
         run: ./gradlew publish
+      - name: Upload reports
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reports-build
+          path: '**/build/reports'

--- a/opa-async-java-client/src/test/java/com/contentgrid/opa/client/OpaClientIntegrationTests.java
+++ b/opa-async-java-client/src/test/java/com/contentgrid/opa/client/OpaClientIntegrationTests.java
@@ -40,7 +40,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 class OpaClientIntegrationTests {
 
-    private static final DockerImageName OPA_IMAGE = DockerImageName.parse("openpolicyagent/opa");
+    private static final DockerImageName OPA_IMAGE = DockerImageName.parse("openpolicyagent/opa:0.70.0");
     private static final int OPA_EXPOSED_PORT = 8181;
 
     @Container


### PR DESCRIPTION
Openpolicyagent v1.0 breaks the syntax, this PR sets the version used in tests to 0.70.0 (the latest version using the old syntax), so that github actions builds succeed again.